### PR TITLE
Made sure that the ray direction is properly calculated in rasterize

### DIFF
--- a/hillshade/hillshade.py
+++ b/hillshade/hillshade.py
@@ -41,7 +41,7 @@ def hillshade(elevation_model, resolution, zenith, ray, ystart, yend):
         shadow (np.ndarray):
             an array of ones where there is shade and zeros otherwise
     """
-    if max(ray) != 1.:
+    if max(np.abs(np.array(ray))) != 1.:
         raise ValueError("xy-direction is not rasterized.")
     shadow = np.zeros((yend - ystart, elevation_model.shape[1]), dtype=np.int64)
     zenith = np.deg2rad(90 - zenith)

--- a/hillshade/scripts/cli.py
+++ b/hillshade/scripts/cli.py
@@ -66,13 +66,21 @@ def rasterize(azimuth, transform=None):
         xdir -= transform.xoff
         ydir -= transform.yoff
 
-    slope = ydir / xdir
+        signx=np.sign(xdir)
+        signy=np.sign(ydir)
+
+    slope = np.absolute(ydir / xdir)
+
     if slope < 1. and slope > -1.:
         xdir = 1.
         ydir = slope
     else:
         xdir = 1. / slope
         ydir = 1.
+
+    xdir= signx*xdir
+    ydir= signy*ydir
+
     return xdir, ydir
 
 


### PR DESCRIPTION
Resolve #3

Running the test in the issue produces correct ray orientation:
![fix](https://user-images.githubusercontent.com/114110631/221821528-722293a1-1c5e-4541-8883-6b2db3e519c9.png)

I also tested it with real DEM.
